### PR TITLE
Activate the streaming handler

### DIFF
--- a/src/CommandBus/Command/StreamingRequestCommand.php
+++ b/src/CommandBus/Command/StreamingRequestCommand.php
@@ -6,7 +6,7 @@ use Psr\Http\Message\RequestInterface;
 use WyriHaximus\Tactician\CommandHandler\Annotations\Handler;
 
 /**
-* @Handler(StreamingRequestHandler::class)
+ * @Handler("ApiClients\Foundation\Transport\CommandBus\Handler\StreamingRequestHandler")
  */
 final class StreamingRequestCommand implements RequestCommandInterface
 {


### PR DESCRIPTION
While playing around with the twitter api-client, I noticed that the `StreamingRequestHandler` wasn't added to the `commandNameToHandlerMap` property of the `CommandHandlerMiddleware`.
This resulted in the streaming API that wouldn't work anymore. I've changed the `@Handler` annotation to the FQCN like in the other Request classes. Now the stream API works well.